### PR TITLE
Fix scp from host to DTS not working without -O flag 

### DIFF
--- a/meta-dts-distro/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-dts-distro/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,1 +1,6 @@
 SYSTEMD_AUTO_ENABLE:${PN}-sshd = "disable"
+
+do_install:append() {
+    # replace /usr/libexec/sftp-server with internal-sftp.
+    sed -i -r -e "s|^(Subsystem[[:space:]]*sftp[[:space:]]*)/usr/libexec/sftp-server|\1internal-sftp|" ${D}${sysconfdir}/ssh/sshd_config
+}


### PR DESCRIPTION
Fixes https://github.com/Dasharo/dasharo-issues/issues/840.
Had to use sed to modify sshd_config because changes made in patch were getting overwritten somewhere.
Log shows that patch was applied last but somehow changes got reverted:

```
NOTE: Applying patch 'fix-potential-signed-overflow-in-pointer-arithmatic.patch' (/work/poky/meta/recipes-connectivity/openssh/openssh/fix-potential-signed-overflow-in-pointer-arithmatic.patch)
NOTE: Applying patch 'add-test-support-for-busybox.patch' (/work/poky/meta/recipes-connectivity/openssh/openssh/add-test-support-for-busybox.patch)
NOTE: Applying patch 'f107467179428a0e3ea9e4aa9738ac12ff02822d.patch' (/work/poky/meta/recipes-connectivity/openssh/openssh/f107467179428a0e3ea9e4aa9738ac12ff02822d.patch)
NOTE: Applying patch '0001-Default-to-not-using-sandbox-when-cross-compiling.patch' (/work/poky/meta/recipes-connectivity/openssh/openssh/0001-Default-to-not-using-sandbox-when-cross-compiling.patch)
NOTE: Applying patch '0001-sshd_config-use-internal-sftp.patch' (/repo/meta-dts-distro/recipes-connectivity/openssh/openssh/0001-sshd_config-use-internal-sftp.patch)
DEBUG: Python function patch_do_patch finished
DEBUG: Python function do_patch finished
```