### PR TITLE
openssh_%.bbappend: use sshd.service instead of sshd.socket

### DIFF
--- a/meta-dts-distro/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-dts-distro/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,3 +1,4 @@
+PACKAGECONFIG += "systemd-sshd-service-mode"
 SYSTEMD_AUTO_ENABLE:${PN}-sshd = "disable"
 
 do_install:append() {

--- a/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
+++ b/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=c846ebb396f8b174b10ded477
 PV = "0.1+git${SRCPV}"
 
 SRC_URI = "git://github.com/Dasharo/dts-scripts;protocol=https;branch=main"
-SRCREV = "019212bf44a5fade576e4d02c9f093cffda6af8e"
+SRCREV = "1932a7823e3a751ddc039068a6e7558ab4170d8d"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
sshd.service was autogenerated by systemd as init.d script and was not disabled so we can just use sshd.service explicitly and it will be disabled by default.

https://github.com/Dasharo/dts-scripts/pull/17 must be merged first