### PR TITLE
distro: dts-scripts: use proper mocking on QEMU

### DIFF
--- a/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
+++ b/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=c846ebb396f8b174b10ded477
 PV = "0.1+git${SRCPV}"
 
 SRC_URI = "git://github.com/Dasharo/dts-scripts;protocol=https;branch=main"
-SRCREV = "12e417bbc781ba5e180eba26ef574298ce2b7156"
+SRCREV = "63d6d3187c8d38697925e16713c89e0062bb06f6"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This commit uses the dts-scripts with the mocking fixed as a part of the following PRs:
* https://github.com/Dasharo/open-source-firmware-validation/pull/999
* https://github.com/Dasharo/dts-scripts/pull/97