### PR TITLE
Add ttyusb0 console

### DIFF
--- a/meta-dts-distro/wic/usb-stick-dts.wks.in
+++ b/meta-dts-distro/wic/usb-stick-dts.wks.in
@@ -1,4 +1,4 @@
-bootloader --timeout=0 --append=" rootwait"
+bootloader --timeout=0 --append=" rootwait console=ttyUSB0"
 
 part /boot --source bootimg-biosplusefi --sourceparams="loader=grub-efi" --ondisk sda --label dts-boot --align 1024 --use-uuid --active --system-id 0xef
 part /     --source rootfs --fstype=ext4                                 --ondisk sda --label dts-root --align 1024 --use-uuid --fixed-size 1024

--- a/scripts/generate-ipxe-menu.sh
+++ b/scripts/generate-ipxe-menu.sh
@@ -36,6 +36,6 @@ set path_initrd \${dts_prefix}/dts-base-image-\${dts_version}.cpio.gz
 imgfetch --name file_kernel \${path_kernel}
 imgfetch --name file_initrd \${path_initrd}
 
-kernel file_kernel initrd=file_initrd
+kernel file_kernel initrd=file_initrd console=ttyUSB0
 boot
 EOF


### PR DESCRIPTION
```
bash-5.2# tty
/dev/ttyUSB0
bash-5.2# cat /proc/cmdline
BOOT_IMAGE=/bzImage root=PARTUUID=076c4a2a-02 rootwait rootwait console=ttyUSB0 quiet
```

I also still have DTS UI on other ttys e.g. tty1 on NUC-155H