### PR TITLE
dts-scripts: multiple fixes related to fum, flashing, logs, (...)

### DIFF
--- a/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
+++ b/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=c846ebb396f8b174b10ded477
 PV = "0.1+git${SRCPV}"
 
 SRC_URI = "git://github.com/Dasharo/dts-scripts;protocol=https;branch=main"
-SRCREV = "b43ab58df36dbe6fa55f044b45860c9565a2c1ea"
+SRCREV = "d638d0f5d2e7344ef99b0525aacdc8cb432cee18"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Changes in dts-scripts:
  - ask if user wants to continue if smmstore migration fails
  - stop update if `flashrom` can't read flash in `set_flashrom_update_params`
  - rework send_dts_logs function
      - fix visible error when no network interface
      - print link to docs if sending logs fails - send logs to public hcl if DPP credentials don't work - print path to created archive in case user wants to copy them manually
  - add recovery/brick warnings and contact information in case flashing fails
  - replace MinIO text displayed for users with 3mdeb server
  - add fix for multiple FUM updates starting. Ask user if they want to start automatic update or go to main menu.

---

Related PRs: https://github.com/Dasharo/dts-scripts/pull/113