### PR TITLE
Add file as usb to qemu

### DIFF
--- a/scripts/run-qemu.sh
+++ b/scripts/run-qemu.sh
@@ -35,6 +35,7 @@ Options:
   -s|--secure-boot          Enable Secure Boot with EFI BIOS.
   -t|--tpm                  Add TPM2 device
   -n|--no-graphics          No graphic mode, only serial
+  -p|--port                 Change SSH port (5222 by default)
   -m|--memory <mem>         How much RAM should QEMU have (default: 2G)
   -c|--cpu <cpu>            How many vCPUs should QEMU create (default: 4)
   -u|--usb <file>           Add <file> as an removable USB device
@@ -85,6 +86,10 @@ parse_args() {
         NO_GRAPHIC="-nographic"
         shift
         ;;
+      -p|--port)
+        PORT="$2"
+        shift 2
+        ;;
       -m|--memory)
         MEM="$2"
         shift 2
@@ -122,6 +127,7 @@ parse_args() {
 
 POSITIONAL_ARGS=()
 KVM=(-enable-kvm)
+PORT=5222
 MEM="2G"
 CPU="4"
 EFI=
@@ -166,6 +172,6 @@ fi
 qemu-system-x86_64 -serial mon:stdio -global ICH9-LPC.disable_s3=1 \
   "${OVMF[@]}" \
   -device virtio-net,netdev=vmnic \
-  -netdev user,id=vmnic,hostfwd=tcp::5222-:22 \
+  -netdev user,id=vmnic,hostfwd=tcp::"${PORT}"-:22 \
   -m "$MEM" -smp "$CPU" -M q35 "${KVM[@]}" "${TPM_ARGS[@]}" \
   $NO_GRAPHIC "${USB[@]}" "${POSITIONAL_ARGS[@]}"


### PR DESCRIPTION
To test usb:

```
dd if=/dev/zero of=usb1 bs=1M count=1000
dd if=/dev/zero of=usb2 bs=1M count=1000
./run-qemu.sh -n -u usb1 -u usb2  dts.img
```

In DTS shell:

```sh
bash-5.2# ls -l "/dev/disk/by-id/usb"*
lrwxrwxrwx 1 root root 9 Oct  6 07:37 /dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:03.0-1-0:0 -> ../../sdb
lrwxrwxrwx 1 root root 9 Oct  6 07:37 /dev/disk/by-id/usb-QEMU_QEMU_HARDDISK_1-0000:00:03.0-2-0:0 -> ../../sdc

bash-5.2# lsblk /dev/sdb /dev/sdc
NAME
    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
sdb   8:16   1 1000M  0 disk
sdc   8:32   1 1000M  0 disk
```

Mainly used during Zarhus OS testing (not sure if we want to create copy in meta-zarhus).

Also:
- add argument to modify ssh port used (useful in case you have OSFV QEMU running)
- set cpu model so booting DTS without `-enable-kvm` works. DTS boots but is very slow.