### PR TITLE
dts-scripts: use dts-configs develop by default for nightly builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,11 @@ jobs:
       dts_scripts_hash_nightly: ${{ steps.set_dts_scripts_hash_output.outputs.hash }}
     steps:
       - name: Checkout meta-dts repo
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v4
         with:
           path: "meta-dts"
           ref: ${{ inputs.ref }}
-      - name: Prepare nightly SRCREV
+      - name: Prepare nightly DTS settings
         if: ${{ inputs.nightly == true }}
         id: set_dts_scripts_hash_output
         shell: bash
@@ -45,14 +45,16 @@ jobs:
           DTS_SCRIPTS_HASH=$(cd dts-scripts-tmp && git rev-parse HEAD)
           echo "hash=${DTS_SCRIPTS_HASH}" >> $GITHUB_OUTPUT
           rm -rf dts-scripts-tmp
+
           FILE_PATH="meta-dts/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb"
-          if [ -f "$FILE_PATH" ]; then
-            sed -i "s/^SRCREV = \".*\"/SRCREV = \"${DTS_SCRIPTS_HASH}\"/" "$FILE_PATH"
-            echo "Updated SRCREV in $FILE_PATH to ${DTS_SCRIPTS_HASH}"
-          else
-            echo "Error: File $FILE_PATH not found. Cannot update SRCREV."
+          if [ ! -f "$FILE_PATH" ]; then
+            echo "Error: File $FILE_PATH not found. Cannot update nightly settings."
             exit 1
           fi
+
+          sed -i "s/^SRCREV = \".*\"/SRCREV = \"${DTS_SCRIPTS_HASH}\"/" "$FILE_PATH"
+
+          echo "Updated nightly SRCREV in $FILE_PATH to ${DTS_SCRIPTS_HASH}"
       - name: Prepare cache-less build configuration
         if: ${{ inputs.cacheless }}
         shell: bash

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       cacheless: true
-      kas-path: meta-dts/kas-uefi-sb.yml
+      kas-path: 'meta-dts/kas-uefi-sb.yml:meta-dts/kas/develop.yml'
       ref: develop
       nightly: true
 
@@ -31,7 +31,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       cacheless: true
-      kas-path: meta-dts/kas.yml
+      kas-path: 'meta-dts/kas.yml:meta-dts/kas/develop.yml'
       ref: develop
       nightly: true
 
@@ -68,7 +68,7 @@ jobs:
       labels: dts-builder
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v4
         with:
           ref: develop
           fetch-depth: 1

--- a/kas/develop.yml
+++ b/kas/develop.yml
@@ -1,0 +1,7 @@
+---
+header:
+  version: 14
+
+local_conf_header:
+  dts_configs_ref: |
+    DTS_CONFIGS_REF = "refs/heads/develop"

--- a/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
+++ b/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=c846ebb396f8b174b10ded477
 PV = "0.1+git${SRCPV}"
 
 SRC_URI = "git://github.com/Dasharo/dts-scripts;protocol=https;branch=main"
-SRCREV = "6dd5a1c94cd898e144bfff7946dabac39a3b9c9a"
+SRCREV = "4b0cc017efa7c895b9169f79f999c9278163eec6"
 
 S = "${WORKDIR}/git"
 
@@ -34,6 +34,8 @@ RDEPENDS:${PN} = " \
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"
 
+DTS_CONFIGS_REF ?= "refs/heads/main"
+
 do_install () {
-    oe_runmake install DESTDIR="${D}"
+    oe_runmake install DESTDIR="${D}" DTS_CONFIGS_REF="${DTS_CONFIGS_REF}"
 }


### PR DESCRIPTION
## Summary
Set `DTS_CONFIG_REF` to `refs/heads/develop` in the generated `dts-environment.sh` for images built from `meta-dts` develop.

## Why
Nightly DTS images are built from `meta-dts` develop and should consume `dts-configs` develop out of the box. Currently they default to `refs/heads/main`, which mismatches nightly expectations.

## Change
- In `dts-scripts_git.bb` `do_install`, patch installed `dts-environment.sh`:
  - `refs/heads/main` -> `refs/heads/develop`

## Validation
- Static recipe-level check: patched file path `${D}${sbindir}/dts-environment.sh` exists after install step.
- Functional expectation: booting nightly DTS and running
  - `source /usr/sbin/dts-environment.sh; echo $DTS_CONFIG_REF`
  should now print `refs/heads/develop`.

Fixes: Dasharo/dasharo-issues#1790
